### PR TITLE
Fixing icon image alpha

### DIFF
--- a/3rdparty/blendish/blendish.h
+++ b/3rdparty/blendish/blendish.h
@@ -1451,7 +1451,7 @@ void bndIcon(NVGcontext *ctx, float x, float y, int iconid) {
         nvgImagePattern(ctx,x-u,y-v,
         BND_ICON_SHEET_WIDTH,
         BND_ICON_SHEET_HEIGHT,
-        0,bnd_icon_image,0));
+        0,bnd_icon_image,1));
     nvgFill(ctx);
 }
 


### PR DESCRIPTION
Alpha was null when splating icons, resulting in no icons when using blendish.
